### PR TITLE
Add testgroup parameter to cluster-config and use it in pre-fio-all

### DIFF
--- a/storage-validation-toolkit/cluster-config
+++ b/storage-validation-toolkit/cluster-config
@@ -25,6 +25,7 @@ echo "You must edit the cluster-config file before running the scripts in this t
 hostgroups=( "master1" "master2" "worker" "edge" )
 testdir="fio"
 testuser="cloudera"
+testgroup="cloudera"
 
 # There must be hosts_{group} and dirs_{group} variables defined for each entry in hostgroups above.
 # There must be a type_{group} variable defined as either "master" or "worker" to determine appropriate tests.

--- a/storage-validation-toolkit/pre-fio-dir-all
+++ b/storage-validation-toolkit/pre-fio-dir-all
@@ -27,7 +27,7 @@ do
     
     for dir in ${dirsvar[@]};
     do
-      commandlist="${commandlist} sudo bash -c 'mkdir $dir/$testdir; chown $testuser:$testuser $dir/$testdir;'; "
+      commandlist="${commandlist} sudo bash -c 'mkdir $dir/$testdir; chown $testuser:$testgroup $dir/$testdir;'; "
     done
     
     # The following commands are used to install fio and iperf3 for further testing.  These commands have been tested on CentOS 7.4 and


### PR DESCRIPTION
Add testgroup parameter to cluster-config and use it in pre-fio-all. For environments where group name do not match username